### PR TITLE
Fixed examples running on linux using SDL2.

### DIFF
--- a/examples/sdl_platform.nim
+++ b/examples/sdl_platform.nim
@@ -13,8 +13,9 @@ proc GetTime*(): float64 =
     return cast[float64](getPerformanceCounter()*1000) / cast[float64](getPerformanceFrequency())
 
 proc LinkSDL2WithBGFX(window: Window) =
-    var pd: ptr PlatformData = create(PlatformData) 
+    var pd: ptr PlatformData = create(PlatformData)
     var info: SysWMinfo
+    version(info.version)
     assert getWindowWMInfo(window, addr(info))
     echo "SDL2 version: $1.$2.$3 - Subsystem: $4".format(info.version.major.int, info.version.minor.int, info.version.patch.int, info.subsystem)
     case(info.subsystem):


### PR DESCRIPTION
This `version` line is apparently necessary.  I got it from [Vladar4's examples](https://github.com/Vladar4/sdl2_nim/blob/master/examples/ex105_syswm.nim#L30).

Without this, `info.subsystem` is `SysWM_Unknown`, rather than `SysWM_X11`.