### PR TITLE
fix metaballs

### DIFF
--- a/examples/00-HelloWorld/HelloWorld.nim.cfg
+++ b/examples/00-HelloWorld/HelloWorld.nim.cfg
@@ -5,9 +5,14 @@
 --clibdir:"/usr/local/lib"
 --passC:"-o2"
 --define:BGFX_BUILD_LIB
+--define:useSDL
 
 #If Windows and SDL
 #--define:SDL_VIDEO_DRIVER_WINDOWS
 
 #If Linux and SDL
 #--define:SDL_VIDEO_DRIVER_X11
+
+#If OSX and SDL
+#--define:SDL_VIDEO_DRIVER_COCOA
+

--- a/examples/01-Cubes/Cubes.nim.cfg
+++ b/examples/01-Cubes/Cubes.nim.cfg
@@ -12,3 +12,6 @@
 
 #If Linux and SDL
 #--define:SDL_VIDEO_DRIVER_X11
+
+#If OSX and SDL
+#--define:SDL_VIDEO_DRIVER_COCOA

--- a/examples/02-metaballs/Metaballs.nim
+++ b/examples/02-metaballs/Metaballs.nim
@@ -639,7 +639,7 @@ proc Update(self: ExampleMetaball) =
                 xx = xx+1
             yy = yy+1
         zz = zz+1
-    
+
     prof_triangulate = GetTime()-prof_triangulate
 
     var mtx: Mat4

--- a/examples/02-metaballs/Metaballs.nim
+++ b/examples/02-metaballs/Metaballs.nim
@@ -381,7 +381,7 @@ proc triangulate*(vert_result: var ptr PosNormalColorVertex; stride: int; rgb: a
     let flags: uint16 = s_edges[cubeindex]
     var ii: uint16 = 0'u16
     while ii < 12'u16:
-        if (flags and (1'u16 shl ii)) == 1:
+        if (flags and (1'u16 shl ii)) != 0:
             let idx0: uint32 = ii and 7
             let idx1: uint32 = [
                 0x00000001'u32, 0x00000002'u32, 0x00000003'u32, 0x00000000'u32,
@@ -475,11 +475,12 @@ proc Start(self: ExampleMetaball) =
 proc CleanUp(self: ExampleMetaball) =
     bgfx.DestroyProgram(self.m_program)
     bgfx.Shutdown()
+    sleep(3)
 
 proc Update(self: ExampleMetaball) =
     const y_pitch = DIMS
     const z_pitch = DIMS*DIMS
-    const inv_dim = 1.0'f32/DIMS-1
+    const inv_dim = 1.0'f32/(FDIMS-1)
     let stride = cast[int](s_metaballVertices_Decl.GetStride())
 
     # Set view 0 default viewport
@@ -487,11 +488,10 @@ proc Update(self: ExampleMetaball) =
 
     var now = GetTime()
     var last {.global.} = GetTime()
-    let frameTime: float32 = now-last
-    var time = GetTime()
+    let frameTime: float32 =  now - last
     last = now
-    const toMs = 1000.0'f64
-
+    var time = now / 1e3       # slow down a bit
+    
     # Use debug font to print information about this example.
     bgfx.DebugTextClear()
     bgfx.DebugTextPrintf(0, 1, 0x4f, "nim-bgfx/examples/02-metaballs")
@@ -532,7 +532,7 @@ proc Update(self: ExampleMetaball) =
     var index = 0
     while index < num_spheres:
         let fii = float32(index)
-        let HDIM = DIMS*0.5'f32
+        let HDIM = FDIMS*0.5'f32
         sphere[index][0] = fpumath.fsin(time*(fii*0.21'f32)+fii*0.37'f32)*(HDIM-8.0'f32)
         sphere[index][1] = fpumath.fsin(time*(fii*0.37'f32)+fii*0.67'f32)*(HDIM-8.0'f32)
         sphere[index][2] = fpumath.fcos(time*(fii*0.11'f32)+fii*0.13'f32)*(HDIM-8.0'f32)
@@ -540,7 +540,7 @@ proc Update(self: ExampleMetaball) =
         index = index+1
 
     prof_update = GetTime() 
-
+    
     var zz = 0
     var yy = 0
     var xx = 0
@@ -594,7 +594,7 @@ proc Update(self: ExampleMetaball) =
         zz = zz+1
 
     prof_normal = GetTime()-prof_normal
-
+    
     prof_triangulate = GetTime()
 
     var current_pos = cast[ptr PosNormalColorVertex](tvb.data)
@@ -607,7 +607,7 @@ proc Update(self: ExampleMetaball) =
         rgb[5] = (fzz+1)*inv_dim
         yy = 0
         while yy < DIMS-1 and num_vertices+12 < max_vertices:
-            let fyy = float32(yy)
+            let fyy = float32(yy)   
             let offset = (zz*DIMS+yy)*DIMS
             rgb[1] = fyy*inv_dim
             rgb[4] = (fyy+1)*inv_dim
@@ -635,13 +635,12 @@ proc Update(self: ExampleMetaball) =
                     addr(self.m_grid[xoffset+1]),
                     addr(self.m_grid[xoffset])
                 ]
-                let num = triangulate(current_pos, stride, rgb, pos, val, 0.5'f32)
-                current_pos = cast[ptr PosNormalColorVertex](cast[ByteAddress](current_pos)+int(num))
-                num_vertices = num_vertices+int(num)
+                var vnum = triangulate(current_pos, stride, rgb, pos, val, 0.5'f32)
+                num_vertices = num_vertices+int(vnum)
                 xx = xx+1
             yy = yy+1
         zz = zz+1
-
+    
     prof_triangulate = GetTime()-prof_triangulate
 
     var mtx: Mat4
@@ -657,13 +656,11 @@ proc Update(self: ExampleMetaball) =
     bgfx.Submit(0, self.m_program)
 
     bgfx.DebugTextPrintf(1, 4, 0x0f, "Num vertices: %5d (%6.4f%%)", num_vertices, num_vertices.toFloat()/max_vertices.toFloat()*100)
-    bgfx.DebugTextPrintf(1, 5, 0x0f, "      Update: % 7.3f[ms]", prof_update*toMs)
-    bgfx.DebugTextPrintf(1, 6, 0x0f, "Calc Normals: % 7.3f[ms]", prof_normal*toMs)
-    bgfx.DebugTextPrintf(1, 7, 0x0f, " Triangulate: % 7.3f[ms]", prof_triangulate*toMs)
-    bgfx.DebugTextPrintf(1, 8, 0x0f, "       Frame: %7.3f[ms]", frameTime*toMs);
-    bgfx.DebugTextPrintf(1, 9, 0x0f, "         FPS: %7.3f", 1.0'f32/frameTime);
-
-
+    bgfx.DebugTextPrintf(1, 5, 0x0f, "      Update: %7.3f[ms]", prof_update)
+    bgfx.DebugTextPrintf(1, 6, 0x0f, "Calc Normals: %7.3f[ms]", prof_normal)
+    bgfx.DebugTextPrintf(1, 7, 0x0f, " Triangulate: %7.3f[ms]", prof_triangulate)
+    bgfx.DebugTextPrintf(1, 8, 0x0f, "       Frame: %7.3f[ms]", frameTime)
+    bgfx.DebugTextPrintf(1, 9, 0x0f, "         FPS: %7.3f", 1000.0'f32/frameTime)
     bgfx.Frame()
 
 StartExample[ExampleMetaball]()

--- a/examples/02-metaballs/Metaballs.nim
+++ b/examples/02-metaballs/Metaballs.nim
@@ -475,7 +475,6 @@ proc Start(self: ExampleMetaball) =
 proc CleanUp(self: ExampleMetaball) =
     bgfx.DestroyProgram(self.m_program)
     bgfx.Shutdown()
-    sleep(3)
 
 proc Update(self: ExampleMetaball) =
     const y_pitch = DIMS
@@ -491,7 +490,7 @@ proc Update(self: ExampleMetaball) =
     let frameTime: float32 =  now - last
     last = now
     var time = now / 1e3       # slow down a bit
-    
+
     # Use debug font to print information about this example.
     bgfx.DebugTextClear()
     bgfx.DebugTextPrintf(0, 1, 0x4f, "nim-bgfx/examples/02-metaballs")
@@ -540,7 +539,7 @@ proc Update(self: ExampleMetaball) =
         index = index+1
 
     prof_update = GetTime() 
-    
+
     var zz = 0
     var yy = 0
     var xx = 0
@@ -594,7 +593,7 @@ proc Update(self: ExampleMetaball) =
         zz = zz+1
 
     prof_normal = GetTime()-prof_normal
-    
+
     prof_triangulate = GetTime()
 
     var current_pos = cast[ptr PosNormalColorVertex](tvb.data)
@@ -607,7 +606,7 @@ proc Update(self: ExampleMetaball) =
         rgb[5] = (fzz+1)*inv_dim
         yy = 0
         while yy < DIMS-1 and num_vertices+12 < max_vertices:
-            let fyy = float32(yy)   
+            let fyy = float32(yy)
             let offset = (zz*DIMS+yy)*DIMS
             rgb[1] = fyy*inv_dim
             rgb[4] = (fyy+1)*inv_dim

--- a/examples/02-metaballs/Metaballs.nim.cfg
+++ b/examples/02-metaballs/Metaballs.nim.cfg
@@ -5,9 +5,14 @@
 --clibdir:"/usr/local/lib"
 --passC:"-o2"
 --define:BGFX_BUILD_LIB
+--define:useSDL
 
 #If Windows and SDL
 #--define:SDL_VIDEO_DRIVER_WINDOWS
 
 #If Linux and SDL
 #--define:SDL_VIDEO_DRIVER_X11
+
+#If OSX and SDL
+#--define:SDL_VIDEO_DRIVER_COCOA
+

--- a/examples/sdl_platform.nim
+++ b/examples/sdl_platform.nim
@@ -18,7 +18,7 @@ import bgfx.platform
 import strutils
 
 proc GetTime*(): float64 =
-    return cast[float64](getPerformanceCounter()*1000) / cast[float64](getPerformanceFrequency())
+    return (float64(getPerformanceCounter()) * 1000'f64) / float64(getPerformanceFrequency())
 
 proc LinkSDL2WithBGFX(window: Window) =
     var pd: PlatformData = PlatformData()
@@ -75,16 +75,20 @@ proc StartExample*[Example]() =
             if(evt.kind == sdl.Quit):
                 quit = true
             elif(evt.kind == sdl.WINDOWEVENT):
-                var windowEvent = cast[WindowEventObj](evt.addr)
-                var current_width, current_height: cint
-                sdl.glGetDrawableSize(window, current_width.addr, current_height.addr)
-                if cast[uint32](current_width) != app.m_width or cast[uint32](current_height) != app.m_height:
-                    echo "Window resize: ($1, $2)".format(current_width, current_height)
-                    app.m_width = cast[uint32](current_width)
-                    app.m_height = cast[uint32](current_height)
-                    app.m_window_width = cast[uint32](windowEvent.data1)
-                    app.m_window_height = cast[uint32](windowEvent.data2)
+                case evt.window.event
+                of WINDOWEVENT_SIZE_CHANGED:
+                    var current_width, current_height: cint
+                    sdl.glGetDrawableSize(window, current_width.addr, current_height.addr)
+                    if cast[uint32](current_width) != app.m_width or cast[uint32](current_height) != app.m_height:
+                        echo "Window resize: ($1, $2)".format(current_width, current_height)
+                        app.m_width = cast[uint32](current_width)
+                        app.m_height = cast[uint32](current_height)
+                    app.m_window_width = cast[uint32](evt.window.data1)
+                    app.m_window_height = cast[uint32](evt.window.data2)
                     bgfx.Reset(cast[uint16](app.m_window_width), cast[uint16](app.m_window_height), app.m_reset)
+                of WINDOWEVENT_CLOSE:
+                    quit = true
+                else: discard
         app.Update()
 
     app.CleanUp()


### PR DESCRIPTION
Hi, I've made a few modifications to 02-metaballs, and a bit of surrounding SDL code.
Mostly works -- I've noticed a few freezes, possibly in debug mode only.

I'm not able to reproduce them, may depend on my setup. Trouble originate in bgfx::setState and nim runtime tries vainly to throw an exception, looping forever.
May be an impedance mismatch between GC and C++ expectations, not sure.

Anyway metaballs are pretty!

Tested with SDL, nim 0.16.0, OS X 10.9.5
